### PR TITLE
Fix ios subscription when receive a invalid date

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -28,6 +28,9 @@ export const fetchClient = (method, requestBody, path, isDev = false) => {
 }
 
 export const formatDate = (timestamp) => {
+  if(!timestamp) {
+    return null
+  }
   return new Date(timestamp).toISOString()
 }
 


### PR DESCRIPTION
Corrige problema onde app_installed_in e app_updated_in ao chamarem formatDate geravam uma exception no IOS que impossibilitava o subscription no banco de dados.